### PR TITLE
(PA-2055) Boost updates

### DIFF
--- a/configs/components/boost.rb
+++ b/configs/components/boost.rb
@@ -23,6 +23,10 @@ component "boost" do |pkg, settings, platform|
     #pkg.apply_patch 'resources/patches/boost/boost-aarch64-flags.patch'
   end
 
+  if platform.is_windows?
+    pkg.apply_patch 'resources/patches/boost/windows-thread-declare-do_try_join_until-as-inline.patch'
+  end
+
   # Package Dependency Metadata
 
   # Build Requirements

--- a/configs/components/boost.rb
+++ b/configs/components/boost.rb
@@ -73,6 +73,7 @@ component "boost" do |pkg, settings, platform|
   gpp = "#{settings[:tools_root]}/bin/g++"
   b2flags = ""
   b2location = "#{settings[:prefix]}/bin/b2"
+  bjamlocation = "#{settings[:prefix]}/bin/bjam"
 
   if platform.is_cross_compiled_linux?
     pkg.environment "PATH" => "/opt/pl-build-tools/bin:$$PATH"
@@ -97,6 +98,7 @@ component "boost" do |pkg, settings, platform|
     pkg.environment "PATH" => "C:/tools/mingw#{arch}/bin:$$PATH"
     pkg.environment "CYGWIN" => "nodosfilewarning"
     b2location = "#{settings[:prefix]}/bin/b2.exe"
+    bjamlocation = "#{settings[:prefix]}/bin/bjam.exe"
     # bootstrap.bat does not take the `--with-toolset` flag
     toolset = "gcc"
     with_toolset = ""
@@ -181,7 +183,8 @@ component "boost" do |pkg, settings, platform|
       "chmod 0644 #{settings[:includedir]}/boost/thread/v2/shared_mutex.hpp",
       # Remove the user-config.jam from the build user's home directory:
       "rm -f ~/user-config.jam",
-      "rm -f #{b2location}"
+      "rm -f #{b2location}",
+      "rm -f #{bjamlocation}",
     ]
   end
 

--- a/resources/files/boost/macos_rpath_install_names.erb
+++ b/resources/files/boost/macos_rpath_install_names.erb
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# This script rewrites the install_name values for any boost dylibs in the
+# `libdir` so that they rely on the @rpath instead of a specific build directory.
+#
+# After building, the `otool -L` output for the boost dylibs looks something like this:
+#
+# /opt/puppetlabs/puppet/lib/libboost_locale.dylib:
+#     boost/bin.v2/libs/locale/build/gcc-4.8.2/release/threading-multi/libboost_locale.dylib (compatibility version 0.0.0, current version 0.0.0)
+#     boost/bin.v2/libs/system/build/gcc-4.8.2/release/threading-multi/libboost_system.dylib (compatibility version 0.0.0, current version 0.0.0)
+#     /usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
+#     /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 307.4.0)
+#     /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.0.0)
+#
+# ...where relative paths to the build directory have been hard-coded. To make these
+# libraries useful after relocation, we update them so that they look like this:
+#
+# /opt/puppetlabs/puppet/lib/libboost_locale.dylib:
+#     @rpath/libboost_locale.dylib (compatibility version 0.0.0, current version 0.0.0)
+#     @rpath/libboost_system.dylib (compatibility version 0.0.0, current version 0.0.0)
+#     /usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
+#     /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 307.4.0)
+#     /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.0.0)
+
+
+LIBDIR=<%= libdir %>
+BOOST_DYLIBS=${LIBDIR}/libboost*.dylib
+
+echo "Updating install_name values for boost dylibs..."
+
+for dylib_path in $BOOST_DYLIBS; do
+  # Update the id of this dylib from the old relative path to '@rpath/libboost_foo.dylib':
+  install_name_tool -id @rpath/$(basename $dylib_path) $dylib_path
+
+  # Update the install_names of each of the boost libraries this library depends on this way, too:
+  linked_boost_libs=$(otool -L $dylib_path | tail -n +2 | grep boost | awk '{ print $1 }')
+  for old_name in $linked_boost_libs; do
+    install_name_tool -change $old_name @rpath/$(basename $old_name) $dylib_path
+  done
+done
+
+echo "Done."

--- a/resources/patches/boost/windows-thread-declare-do_try_join_until-as-inline.patch
+++ b/resources/patches/boost/windows-thread-declare-do_try_join_until-as-inline.patch
@@ -1,0 +1,11 @@
+diff -Naur boost_1_67_0.orig/boost/thread/detail/thread.hpp boost_1_67_0/boost/thread/detail/thread.hpp
+--- boost_1_67_0.orig/boost/thread/detail/thread.hpp	2018-07-16 20:42:54.889539200 +0000
++++ boost_1_67_0/boost/thread/detail/thread.hpp	2018-07-16 20:45:41.436156800 +0000
+@@ -461,7 +461,7 @@
+     private:
+         bool join_noexcept();
+         bool do_try_join_until_noexcept(detail::internal_platform_timepoint const &timeout, bool& res);
+-        bool do_try_join_until(detail::internal_platform_timepoint const &timeout);
++        inline bool do_try_join_until(detail::internal_platform_timepoint const &timeout);
+     public:
+         void join();


### PR DESCRIPTION
Three fixes for boost:
- Add a patch to boost thread for Windows
- Remove the bjam executable after building boost (it can blow up an agent build during packaging for ubuntu on POWER, since it's built for the build host, and we don't want it anyway)
- Rewrite the `install_name` values for boost dylibs on macOS
 
(I'm going to build my branch on Jenkins now instead of locally and run the finished puppet-agent through some tests)