### PR TITLE
(PA-2055) Make list of boost libs configurable

### DIFF
--- a/configs/components/boost.rb
+++ b/configs/components/boost.rb
@@ -59,8 +59,11 @@ component "boost" do |pkg, settings, platform|
   end
 
   # Build-time Configuration
-  boost_libs = [ 'atomic', 'chrono', 'container', 'date_time', 'exception', 'filesystem', 'graph', 'graph_parallel', 'iostreams', 'locale', 'log', 'math', 'program_options', 'random', 'regex', 'serialization', 'signals', 'system', 'test', 'thread', 'timer', 'wave' ]
 
+  boost_libs = settings[:boost_libs] || ['atomic', 'chrono', 'container', 'date_time', 'exception', 'filesystem',
+                                         'graph', 'graph_parallel', 'iostreams', 'locale', 'log', 'math',
+                                         'program_options', 'random', 'regex', 'serialization', 'signals', 'system',
+                                         'test', 'thread', 'timer', 'wave']
   cflags = "-fPIC -std=c99"
   cxxflags = "-std=c++11 -fPIC"
 

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -189,6 +189,11 @@ end
 
 proj.timeout 7200 if platform.is_windows?
 
+# These are the boost libraries we care about for facter and friends
+proj.setting(:boost_libs, ["chrono", "date_time", "filesystem", "locale", "log", "program_options",
+                           "random", "regex", "system", "thread"])
+
+
 # Most branches of puppet-agent use these openssl flags in addition to the defaults in configs/components/openssl.rb -
 # Individual projects can override these if necessary.
 proj.setting(:openssl_extra_configure_flags, [


### PR DESCRIPTION
And restrict the list of libraries included in agent to those required
by facter

(This seems to build an EL 7 agent fine, at least)