### PR TITLE
(maint) Explicitly set OpenSSL version for pe-installer

### DIFF
--- a/configs/projects/pe-installer-runtime.rb
+++ b/configs/projects/pe-installer-runtime.rb
@@ -2,6 +2,7 @@ project 'pe-installer-runtime' do |proj|
   # Used in component configurations to conditionally include dependencies
   proj.setting(:runtime_project, 'pe-installer')
   proj.setting :ruby_version, '2.4.4'
+  proj.setting(:openssl_version, '1.0.2')
   platform = proj.get_platform
 
   proj.version_from_git
@@ -104,7 +105,7 @@ project 'pe-installer-runtime' do |proj|
   # --------------
 
   # Ruby and deps
-  proj.component "openssl"
+  proj.component "openssl-#{proj.openssl_version}"
   proj.component "runtime-pe-installer"
   proj.component "puppet-ca-bundle"
   proj.component "ruby-#{proj.ruby_version}"


### PR DESCRIPTION
There are multiple available versions of OpenSSL now; This explicitly
sets the desired version in the pe-isntaller-runtime project.